### PR TITLE
Update Aemsync and Chalk to newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aem-sync-webpack-plugin",
   "email": "lukaszblasz@gmail.com",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Webpack plugin for aemsync",
   "main": "src/aem-sync-webpack-plugin.js",
   "scripts": {
@@ -10,8 +10,8 @@
   "author": "Łukasz Błaszyński",
   "license": "MIT",
   "dependencies": {
-    "aemsync": "^1.1.1",
-    "chalk": "^1.1.3"
+    "aemsync": "^4",
+    "chalk": "^3"
   },
   "repository": {
     "type": "git",

--- a/src/aem-sync-webpack-plugin.js
+++ b/src/aem-sync-webpack-plugin.js
@@ -1,42 +1,42 @@
-var aemsync = require('aemsync');
-var chalk = require('chalk');
+const aemsync = require('aemsync');
+const chalk = require('chalk');
 
-var initAemSyncWatcher = function(options){
-    var pushInterval = options.pushInterval || 300;
-    var exclude = options.exclude || '';
+const initAemSyncWatcher = function(options){
+    const interval = options.pushInterval || 300;
+    const exclude = options.exclude || '';
 
-    if(!(options && options.targets.length)){
+    if (!(options && options.targets.length)) {
         console.error(chalk.red('AemSync targets property missing!'));
         return;
     }
-    else if(!(options && options.watchDir)){
+    else if (!(options && options.watchDir)) {
         console.error(chalk.red('AemSync workingDir property missing!'));
         return;
     }
 
-    var onPushEnd = function(err, host) {
+    const onPushEnd = function(err, host) {
         if (err) {
             return console.log('Error when pushing package', err);
         }
-        console.log('Package pushed to' + host)
+        console.log('Package pushed to: ' + host);
     };
 
-    var pusher = new aemsync.Pusher(options.targets, pushInterval, onPushEnd);
-    var watcher = new aemsync.Watcher();
-
-    pusher.start();
-    watcher.watch(options.watchDir, exclude, function(localPath){
-        pusher.enqueue(localPath)
+    aemsync(options.watchDir, {
+      targets: options.targets,
+      exclude,
+      interval,
+      packmgrUrl: null,
+      onPushEnd,
+      checkBeforePush: true,
     });
 };
-
 
 function AemSyncPlugin(options) {
     this.options = options;
 }
 
 AemSyncPlugin.prototype.apply = function () {
-    if(process.argv.indexOf('--watch') != -1){
+    if (process.argv.indexOf('--watch') != -1) {
         initAemSyncWatcher(this.options);
     }
 };


### PR DESCRIPTION
Dependencies for Aemsync 1.1.1 have some security issues, so I've updated the script to support the newest Aemsync (at the moment it's 4.0.0).
Updating Chalk version didn't require any changes in code.
Bonus: I've changed `var` to `const`.